### PR TITLE
⚡️ Add delay to loading indicator

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -25,10 +25,21 @@ import topbar from "../vendor/topbar"
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})
 
-// Show progress bar on live navigation and form submits
-topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
-window.addEventListener("phx:page-loading-start", info => topbar.show())
-window.addEventListener("phx:page-loading-stop", info => topbar.hide())
+// Show progress bar on live navigation and form submits. Only displays if still
+// loading after 120 msec
+topbar.config({ barColors: { 0: "#29d" }, shadowColor: "rgba(0, 0, 0, .3)" });
+
+let topBarScheduled = undefined;
+window.addEventListener("phx:page-loading-start", () => {
+  if (!topBarScheduled) {
+    topBarScheduled = setTimeout(() => topbar.show(), 120);
+  }
+});
+window.addEventListener("phx:page-loading-stop", () => {
+  clearTimeout(topBarScheduled);
+  topBarScheduled = undefined;
+  topbar.hide();
+});
 
 // connect if there are any LiveViews on the page
 liveSocket.connect()


### PR DESCRIPTION
This change makes the navigation feel faster to the user by not showing
the top bar on loadings that require less than 120 ms to load.

Learn more here[^1].

[^1]: https://fly.io/phoenix-files/make-your-liveview-feel-faster/
